### PR TITLE
fix: safari does not support lookbehind

### DIFF
--- a/src/enhancement-functions/getLocalizedRouteFromPathname.ts
+++ b/src/enhancement-functions/getLocalizedRouteFromPathname.ts
@@ -77,7 +77,7 @@ export function getLocalizedRouteFromPathname<
         }
 
         // Required catch-all params
-        if (localizedRoute.match(/(?<!\[)\[\.\.\./)) {
+        if (localizedRoute.includes("[...")) {
           return replaceCatchAllSegments(
             pathnameSegments,
             localizedRouteSegments,


### PR DESCRIPTION
lookbehind is not supported by safari and it is also rendundant since this condition is solved by early return few lines up